### PR TITLE
unnecessary variable in blockchain.cpp's readMagicNumber implementation

### DIFF
--- a/src/sources/blockchain.cpp
+++ b/src/sources/blockchain.cpp
@@ -45,7 +45,7 @@ bool Blockchain::parseFile()
 
 void Blockchain::readMagicNumber(std::ifstream& file)
 {
-    unsigned bufferSize = MAGIC_NUMBER_SIZE;
+    const unsigned bufferSize = MAGIC_NUMBER_SIZE;
     char buffer[bufferSize];
     file.read(buffer, bufferSize);
 


### PR DESCRIPTION
Issue location: blockchain.cpp's readMagicNumber implementation
Severity: very low
Description: The function's first line defines a bufferSize variable which then gets the MAGIC_NUMBER_SIZE constant value assigned to it. Then the variable is used to create an array and is passed to functions. Using a variable to do this is unnecessary. Found this bug with help of cpplint's following warning: `src/sources/blockchain.cpp:49:  Do not use variable-length arrays.  Use an appropriately named ('k' followed by CamelCase) compile-time constant for the size.  [runtime/arrays] [1]`
Remediation: Remove variable declaration and replace occurences with the MAGIC_NUMBER_SIZE constant