### PR TITLE
Suggested renaming of Block class' getTx function and tx field

### DIFF
--- a/src/include/block.h
+++ b/src/include/block.h
@@ -41,7 +41,7 @@ private:
     /**
      * @brief tx vector of transactions
      */
-    std::vector<Transaction> tx;
+    std::vector<Transaction> txVector;
     /**
      * @brief headerOffsets start and end offsets of block header
      */
@@ -59,7 +59,7 @@ public:
 
     /**
      * @brief Block Constructor of data holding structure
-     * @param buffer memory to parse to corrsponding values
+     *Vector @param buffer memory to parse to corrsponding values
      * @param size size of the buffer
      */
     Block(std::unique_ptr<char[]> buffer, uint32_t size);
@@ -107,10 +107,10 @@ public:
     uint32_t getSize() const;
 
     /**
-     * @brief getTx getter for private member: vector of transactions
+     * @brief getTxVector getter for private member: vector of transactions
      * @return vector of transactions
      */
-    std::vector<Transaction> getTx() const;
+    std::vector<Transaction> getTxVector() const;
 
     /**
      * @brief getBinBufferData getter for private member: binary data of block

--- a/src/sources/block.cpp
+++ b/src/sources/block.cpp
@@ -52,7 +52,7 @@ Block::Block(std::unique_ptr<char[]> buffer, uint32_t size) : size(size)
     size_t unread_size = size - offset;
     for(size_t i = 0; i < countTx.first; ++i)
     {
-        tx.emplace_back(Transaction(binBuffer.get()+offset, offset, unread_size));
+        txVector.emplace_back(Transaction(binBuffer.get()+offset, offset, unread_size));
     }
 
 }
@@ -92,9 +92,9 @@ uint32_t Block::getSize() const
     return size;
 }
 
-std::vector<Transaction> Block::getTx() const
+std::vector<Transaction> Block::getTxVector() const
 {
-    return tx;
+    return txVector;
 }
 
 char* Block::getBinBufferData() const
@@ -120,7 +120,7 @@ std::ostream& operator<< (std::ostream& stream, const Block& block)
         stream << "Time: " << std::asctime(std::localtime(&time));
         stream << "Bits: " << std::hex << block.bits << std::endl;
         stream << "Nonce: " << std::dec << block.nonce << std::endl;
-        for(auto& it : block.tx)
+        for(auto& it : block.txVector)
         {
             stream << it << std::endl;
         }

--- a/src/sources/validator.cpp
+++ b/src/sources/validator.cpp
@@ -33,7 +33,7 @@ bool Validator::validateBlock(const Block &head, const Block &predecessor){
     if (!timestampNotTooNew(head,currentTime)) return setIsValidBlockAttribute(head,false, "Invalid timestamp");
 
     //transaction list nonempty
-    if (!transactionListNonempty(head.tx)) return setIsValidBlockAttribute(head,false, "Empty transaction list");
+    if (!transactionListNonempty(head.txVector)) return setIsValidBlockAttribute(head,false, "Empty transaction list");
 
     //Verify Merkle hash
     if(!verifyMerkleHash(head)) return setIsValidBlockAttribute(head,false, "Invalid merkle root hash");
@@ -43,7 +43,7 @@ bool Validator::validateBlock(const Block &head, const Block &predecessor){
 
 bool Validator::validateTransactions(const Block &block){
 
-    const std::vector<Transaction> &transactions = block.tx;
+    const std::vector<Transaction> &transactions = block.txVector;
 
     //first transaction coinbase
     if(!isCoinbase(transactions.at(0))) return setIsValidBlockAttribute(block,false, "First transaction is not coinbase");
@@ -91,8 +91,8 @@ bool Validator::verifyMerkleHash(const Block &block){
 }
 
 
-bool Validator::transactionListNonempty(const std::vector<Transaction> &tx){
-    return tx.size() == 0 ? false : true;
+bool Validator::transactionListNonempty(const std::vector<Transaction> &txVector){
+    return txVector.size() == 0 ? false : true;
 }
 
 bool Validator::isCoinbase(const Transaction &transaction){
@@ -123,7 +123,7 @@ uint256 Validator::hashBlock(const Block &block){
 
 uint256 Validator::computeMerkleHash(const Block &block){
 
-    const std::vector<Transaction> &transactions = block.tx;
+    const std::vector<Transaction> &transactions = block.txVector;
     int baseNoPadding = transactions.size();
     int actualSize = baseNoPadding + baseNoPadding%2;
     unsigned char hashes[actualSize][32];

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -112,7 +112,7 @@ TEST_CASE("Blockchain tests")
         uint32_t expectedLockTime = 0;
 
         const Block& block = chain.getBlocks()[0];
-        Transaction transaction = block.getTx()[0];
+        Transaction transaction = block.getTxVector()[0];
 
         REQUIRE(block.getVersion() == expectedBlockVersion);
         REQUIRE(block.getHashPrevBlock().ToString() == expectedHashPrevBlock);
@@ -121,7 +121,7 @@ TEST_CASE("Blockchain tests")
         REQUIRE(block.getBits() == expectedBits);
         REQUIRE(block.getNonce() == expectedNonce);
         REQUIRE(block.getSize() == expectedSize);
-        REQUIRE(block.getTx().size() == 1);
+        REQUIRE(block.getTxVector().size() == 1);
         REQUIRE(transaction.getVersion() == expectedTransactionVersion);
         REQUIRE(transaction.getLockTime() == expectedLockTime);
         REQUIRE(transaction.getInputs().size() == 1);
@@ -177,8 +177,8 @@ TEST_CASE("Blockchain tests")
         uint32_t expectedLockTime = 0;
 
         const Block& block = chain.getBlocks()[0];
-        Transaction transaction1 = block.getTx()[0];
-        Transaction transaction2 = block.getTx()[0];
+        Transaction transaction1 = block.getTxVector()[0];
+        Transaction transaction2 = block.getTxVector()[0];
 
         REQUIRE(block.getVersion() == expectedBlockVersion);
         REQUIRE(block.getHashPrevBlock().ToString() == expectedHashPrevBlock);
@@ -187,7 +187,7 @@ TEST_CASE("Blockchain tests")
         REQUIRE(block.getBits() == expectedBits);
         REQUIRE(block.getNonce() == expectedNonce);
         REQUIRE(block.getSize() == expectedSize);
-        REQUIRE(block.getTx().size() == 2);
+        REQUIRE(block.getTxVector().size() == 2);
         REQUIRE(transaction1.getVersion() == expectedTransactionVersion);
         REQUIRE(transaction1.getLockTime() == expectedLockTime);
         REQUIRE(transaction1.getInputs().size() == 1);
@@ -257,8 +257,8 @@ TEST_CASE("Blockchain tests")
 
         const Block& block1 = chain.getBlocks()[0];
         const Block& block2 = chain.getBlocks()[1];
-        Transaction transaction1 = block1.getTx()[0];
-        Transaction transaction2 = block2.getTx()[0];
+        Transaction transaction1 = block1.getTxVector()[0];
+        Transaction transaction2 = block2.getTxVector()[0];
 
         REQUIRE(block1.getVersion() == expectedVersion);
         REQUIRE(block1.getHashPrevBlock().ToString() == expectedHashPrevBlock);
@@ -267,7 +267,7 @@ TEST_CASE("Blockchain tests")
         REQUIRE(block1.getBits() == expectedBits);
         REQUIRE(block1.getNonce() == expectedNonce);
         REQUIRE(block1.getSize() == expectedSize);
-        REQUIRE(block1.getTx().size() == 1);
+        REQUIRE(block1.getTxVector().size() == 1);
 
         REQUIRE(block2.getVersion() == expectedVersion);
         REQUIRE(block2.getHashPrevBlock().ToString() == expectedHashPrevBlock);
@@ -276,7 +276,7 @@ TEST_CASE("Blockchain tests")
         REQUIRE(block2.getBits() == expectedBits);
         REQUIRE(block2.getNonce() == expectedNonce);
         REQUIRE(block2.getSize() == expectedSize);
-        REQUIRE(block2.getTx().size() == 1);
+        REQUIRE(block2.getTxVector().size() == 1);
 
         REQUIRE(transaction1.getVersion() == expectedTransactionVersion);
         REQUIRE(transaction1.getLockTime() == expectedLockTime);
@@ -313,13 +313,13 @@ TEST_CASE("Blockchain tests")
         REQUIRE(secondBlock.getBits() == 474114432);
         REQUIRE(secondBlock.getNonce() == 81630126);
         REQUIRE(secondBlock.getSize() == 1562);
-        REQUIRE(secondBlock.getTx().size() == 7);
-        REQUIRE(secondBlock.getTx()[6].getVersion() == 1);
-        REQUIRE(secondBlock.getTx()[4].getLockTime() == 0);
-        REQUIRE(secondBlock.getTx()[3].getInputs().size() == 1);
-        REQUIRE(secondBlock.getTx()[2].getOutputs().size() == 2);
-        REQUIRE(secondBlock.getTx()[1].getInputs()[0].getSeqNumber() == 4294967295);
-        REQUIRE(secondBlock.getTx()[5].getOutputs()[1].getValue() == 176864274);
+        REQUIRE(secondBlock.getTxVector().size() == 7);
+        REQUIRE(secondBlock.getTxVector()[6].getVersion() == 1);
+        REQUIRE(secondBlock.getTxVector()[4].getLockTime() == 0);
+        REQUIRE(secondBlock.getTxVector()[3].getInputs().size() == 1);
+        REQUIRE(secondBlock.getTxVector()[2].getOutputs().size() == 2);
+        REQUIRE(secondBlock.getTxVector()[1].getInputs()[0].getSeqNumber() == 4294967295);
+        REQUIRE(secondBlock.getTxVector()[5].getOutputs()[1].getValue() == 176864274);
     }
 
 
@@ -343,13 +343,13 @@ TEST_CASE("Blockchain tests")
         REQUIRE(fourthBlock.getBits() == 474114432);
         REQUIRE(fourthBlock.getNonce() == 81630126);
         REQUIRE(fourthBlock.getSize() == 1562);
-        REQUIRE(fourthBlock.getTx().size() == 7);
-        REQUIRE(fourthBlock.getTx()[6].getVersion() == 1);
-        REQUIRE(fourthBlock.getTx()[4].getLockTime() == 0);
-        REQUIRE(fourthBlock.getTx()[3].getInputs().size() == 1);
-        REQUIRE(fourthBlock.getTx()[2].getOutputs().size() == 2);
-        REQUIRE(fourthBlock.getTx()[1].getInputs()[0].getSeqNumber() == 4294967295);
-        REQUIRE(fourthBlock.getTx()[5].getOutputs()[1].getValue() == 176864274);
+        REQUIRE(fourthBlock.getTxVector().size() == 7);
+        REQUIRE(fourthBlock.getTxVector()[6].getVersion() == 1);
+        REQUIRE(fourthBlock.getTxVector()[4].getLockTime() == 0);
+        REQUIRE(fourthBlock.getTxVector()[3].getInputs().size() == 1);
+        REQUIRE(fourthBlock.getTxVector()[2].getOutputs().size() == 2);
+        REQUIRE(fourthBlock.getTxVector()[1].getInputs()[0].getSeqNumber() == 4294967295);
+        REQUIRE(fourthBlock.getTxVector()[5].getOutputs()[1].getValue() == 176864274);
     }
 
 
@@ -362,13 +362,13 @@ TEST_CASE("Blockchain tests")
 
         const Block& block = chain.getBlocks()[3];
 
-        Transaction trans1 = block.getTx()[0];
-        Transaction trans2 = block.getTx()[1];
-        Transaction trans3 = block.getTx()[2];
-        Transaction trans4 = block.getTx()[3];
-        Transaction trans5 = block.getTx()[4];
-        Transaction trans6 = block.getTx()[5];
-        Transaction trans7 = block.getTx()[6];
+        Transaction trans1 = block.getTxVector()[0];
+        Transaction trans2 = block.getTxVector()[1];
+        Transaction trans3 = block.getTxVector()[2];
+        Transaction trans4 = block.getTxVector()[3];
+        Transaction trans5 = block.getTxVector()[4];
+        Transaction trans6 = block.getTxVector()[5];
+        Transaction trans7 = block.getTxVector()[6];
 
         REQUIRE(trans1.getOffsets().first == 81);
         REQUIRE(trans1.getOffsets().second == 207);

--- a/tests/testhelper.h
+++ b/tests/testhelper.h
@@ -25,7 +25,7 @@ public:
         ret.nonce = nonce;
         ret.size = size;
         ret.time = time;
-        ret.tx = trans;
+        ret.txVector = trans;
         ret.version = version;
 
         return ret;
@@ -127,9 +127,9 @@ public:
     }
 
 
-    static bool transactionListNonempty(const std::vector<Transaction> &tx)
+    static bool transactionListNonempty(const std::vector<Transaction> &txVector)
     {
-        return Validator::transactionListNonempty(tx);
+        return Validator::transactionListNonempty(txVector);
     }
 
 
@@ -180,9 +180,9 @@ public:
     }
 
 
-    static void setBlockTx(Block &block, const std::vector<Transaction> &tx)
+    static void setBlockTx(Block &block, const std::vector<Transaction> &txVector)
     {
-        block.tx = tx;
+        block.txVector = txVector;
     }
 
 


### PR DESCRIPTION
Issue location: block.h and block.cpp
Severity: only impacts code quality
Description: I advise renaming the Block class' tx field to txVector or txs, as it is a vector of transactions, not a single transaction. Following this pattern, I advise renaming the getTx() function to either getTxs or getTxVector().